### PR TITLE
Enabling fstack_clash_protection for arm32 bit, thumb and thumb2 mode.

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2257,8 +2257,12 @@ void CodeGenModule::SetLLVMFunctionAttributesForDefinition(const Decl *D,
   if ((!D || !D->hasAttr<NoUwtableAttr>()) && CodeGenOpts.UnwindTables)
     B.addUWTableAttr(llvm::UWTableKind(CodeGenOpts.UnwindTables));
 
-  if (CodeGenOpts.StackClashProtector)
+  if (CodeGenOpts.StackClashProtector) {
     B.addAttribute("probe-stack", "inline-asm");
+    if (CodeGenOpts.StackProbeSize != 4096)
+      B.addAttribute("stack-probe-size",
+                     llvm::utostr(CodeGenOpts.StackProbeSize));
+  }
 
   if (!hasUnwindExceptions(LangOpts))
     B.addAttribute(llvm::Attribute::NoUnwind);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3447,11 +3447,18 @@ static void RenderSCPOptions(const ToolChain &TC, const ArgList &Args,
     return;
 
   if (!EffectiveTriple.isX86() && !EffectiveTriple.isSystemZ() &&
-      !EffectiveTriple.isPPC64())
+      !EffectiveTriple.isPPC64() && !EffectiveTriple.isARM() &&
+      !EffectiveTriple.isThumb())
     return;
 
   Args.addOptInFlag(CmdArgs, options::OPT_fstack_clash_protection,
                     options::OPT_fno_stack_clash_protection);
+  if (Args.hasArg(options::OPT_mstack_probe_size)) {
+    StringRef Size = Args.getLastArgValue(options::OPT_mstack_probe_size);
+    CmdArgs.push_back(Args.MakeArgString("-mstack-probe-size=" + Size));
+  } else if (EffectiveTriple.isAArch64()) {
+    CmdArgs.push_back("-mstack-probe-size=65536");
+  }
 }
 
 static void RenderTrivialAutoVarInitOptions(const Driver &D,

--- a/llvm/lib/Target/ARM/ARMFrameLowering.h
+++ b/llvm/lib/Target/ARM/ARMFrameLowering.h
@@ -79,6 +79,10 @@ public:
   const SpillSlot *
   getCalleeSavedSpillSlots(unsigned &NumEntries) const override;
 
+  virtual MachineBasicBlock::iterator
+  insertStackProbingLoop(MachineBasicBlock::iterator MBBI,
+                         Register TargetReg) const ;
+
 private:
   void emitPushInst(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,
                     ArrayRef<CalleeSavedInfo> CSI, unsigned StmOpc,
@@ -94,6 +98,15 @@ private:
   eliminateCallFramePseudoInstr(MachineFunction &MF,
                                 MachineBasicBlock &MBB,
                                 MachineBasicBlock::iterator MI) const override;
+  /// Replace a StackProbe stub (if any) with the actual probe code inline
+  void inlineStackProbe(MachineFunction &MF,
+                        MachineBasicBlock &PrologueMBB) const override;
+  MachineBasicBlock::iterator
+  inlineStackProbeFixed(MachineFunction &MF,
+                        MachineBasicBlock::iterator MBBI) const;
+  MachineBasicBlock::iterator
+  inlineStackProbeVar(MachineFunction &MF,
+                      MachineBasicBlock::iterator MBBI) const;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/ARM/ARMInstrInfo.td
+++ b/llvm/lib/Target/ARM/ARMInstrInfo.td
@@ -2169,6 +2169,10 @@ PseudoInst<(outs), (ins cpinst_operand:$instid, cpinst_operand:$cpidx,
                         i32imm:$size), NoItinerary, []>;
 
 
+def ARMprobedalloca
+    : SDNode<"ARMISD::PROBED_ALLOCA",
+             SDTypeProfile<0, 1, [SDTCisPtrTy<0>]>,
+             [SDNPHasChain]>;
 // FIXME: Marking these as hasSideEffects is necessary to prevent machine DCE
 // from removing one half of the matched pairs. That breaks PEI, which assumes
 // these will always be in pairs, and asserts if it finds otherwise. Better way?
@@ -2180,6 +2184,33 @@ PseudoInst<(outs), (ins i32imm:$amt1, i32imm:$amt2, pred:$p), NoItinerary,
 def ADJCALLSTACKDOWN :
 PseudoInst<(outs), (ins i32imm:$amt, i32imm:$amt2, pred:$p), NoItinerary,
            [(ARMcallseq_start timm:$amt, timm:$amt2)]>;
+
+// Probed stack allocation of a constant size, used in function prologues when
+// stack-clash protection is enabled.
+def PROBED_STACKALLOC : PseudoInst<(outs GPR:$scratch),
+                               (ins i32imm:$stacksize),
+                               NoItinerary,
+                               []>,
+                               Sched<[]>;
+
+// Probed stack allocation of a variable size, used in function prologues when
+// stack-clash protection is enabled. The register input is the target SP,
+// which should be below the current value, and has no alignment requirements
+// beyond the usual 16-byte alignment for SP.
+def PROBED_STACKALLOC_VAR : PseudoInst<(outs),
+                                   (ins GPR:$target),
+                                   NoItinerary,
+                                   []>,
+                                   Sched<[]>;
+
+// Probed stack allocations of a variable size, used for allocas of unknown size
+// when stack-clash protection is enabled.
+def PROBED_STACKALLOC_DYN
+    : PseudoInst<(outs),
+             (ins GPR:$target),
+             NoItinerary,
+             [(ARMprobedalloca GPR:$target)]>,
+      Sched<[]>;
 }
 
 def HINT : AI<(outs), (ins imm0_239:$imm), MiscFrm, NoItinerary,

--- a/llvm/lib/Target/ARM/Thumb1FrameLowering.h
+++ b/llvm/lib/Target/ARM/Thumb1FrameLowering.h
@@ -42,6 +42,16 @@ public:
                                 MachineBasicBlock &MBB,
                                 MachineBasicBlock::iterator MI) const override;
 
+  /// Replace a StackProbe stub (if any) with the actual probe code inline
+  void inlineStackProbe(MachineFunction &MF,
+                        MachineBasicBlock &PrologueMBB) const override;
+  MachineBasicBlock::iterator
+  inlineStackProbeFixed(MachineFunction &MF,
+                        MachineBasicBlock::iterator MBBI) const;
+  MachineBasicBlock::iterator
+  inlineStackProbeVar(MachineFunction &MF,
+                      MachineBasicBlock::iterator MBBI) const;
+
   /// Check whether or not the given \p MBB can be used as a epilogue
   /// for the target.
   /// The epilogue will be inserted before the first terminator of that block.
@@ -53,6 +63,10 @@ public:
   bool enableShrinkWrapping(const MachineFunction &MF) const override {
     return false;
   }
+
+  MachineBasicBlock::iterator
+  insertStackProbingLoop(MachineBasicBlock::iterator MBBI,
+                         Register TargetReg) const override;
 
 private:
   /// Check if the frame lowering of \p MF needs a special fixup


### PR DESCRIPTION
Stack probes are emitted in case of constant arrays, VLA's and alloca, alose if alignment requirement is greater than guard page size.